### PR TITLE
Trim down dev dependencies for faster build and test

### DIFF
--- a/sci-rs/Cargo.toml
+++ b/sci-rs/Cargo.toml
@@ -19,6 +19,7 @@ all-features = true
 default = ['use_std']
 use_std = ['itertools', 'nalgebra/std', 'nalgebra/macros']
 plot = ['gnuplot']
+bench = ['criterion']
 
 [dependencies]
 num-traits = "0.2.15"
@@ -27,13 +28,12 @@ heapless = "0.7.16"
 nalgebra = { version = "0.31.1", default-features = false }
 ndarray = { version = "0.15.6", default-features = false }
 gnuplot = { version = "0.0.37", optional = true }
+criterion = { version = "0.3", features = ["html_reports"], optional = true }
 
 [dev-dependencies]
 approx = "0.5.1"
-bencher = "0.1.5"
-criterion = { version = "0.3", features = ["html_reports"] }
-dasp = { version = "0.11.0", features = ["signal"] }
-itertools = "0.10.3"
+dasp_signal = { version = "0.11.0", default-features = false }
+itertools = "0.10"
 # dhat = "0.3.0"
 
 

--- a/sci-rs/benches/sosfilt.rs
+++ b/sci-rs/benches/sosfilt.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use dasp::{signal, Signal};
+use dasp_signal::{rate, Signal};
 use itertools::Itertools;
 use sci_rs::signal::filter::design::Sos;
 use sci_rs::signal::filter::{sosfilt_dyn, sosfilt_st};
@@ -53,7 +53,7 @@ fn butter_sosfilt_100x_dyn(c: &mut Criterion) {
     // A signal with a frequency that we can recover
     let sample_hz = 1666.;
     let seconds = 10;
-    let mut signal = signal::rate(sample_hz).const_hz(25.).sine();
+    let mut signal = rate(sample_hz).const_hz(25.).sine();
     let sin_wave: Vec<f64> = (0..seconds * sample_hz as usize)
         .map(|_| signal.next())
         .collect_vec();
@@ -113,7 +113,7 @@ fn butter_sosfilt_100x_st(c: &mut Criterion) {
     // A signal with a frequency that we can recover
     let sample_hz = 1666.;
     let seconds = 10;
-    let mut signal = signal::rate(sample_hz).const_hz(25.).sine();
+    let mut signal = rate(sample_hz).const_hz(25.).sine();
     let sin_wave: Vec<f64> = (0..seconds * sample_hz as usize)
         .map(|_| signal.next())
         .collect_vec();
@@ -160,7 +160,7 @@ fn butter_sosfilt_f64(c: &mut Criterion) {
     // A signal with a frequency that we can recover
     let sample_hz = 1666.;
     let seconds = 10;
-    let mut signal = signal::rate(sample_hz).const_hz(25.).sine();
+    let mut signal = rate(sample_hz).const_hz(25.).sine();
     let sin_wave: Vec<f64> = (0..seconds * sample_hz as usize)
         .map(|_| signal.next())
         .collect_vec();
@@ -205,7 +205,7 @@ fn butter_sosfilt_f32(c: &mut Criterion) {
     // A signal with a frequency that we can recover
     let sample_hz = 1666.;
     let seconds = 10;
-    let mut signal = signal::rate(sample_hz).const_hz(25.).sine();
+    let mut signal = rate(sample_hz).const_hz(25.).sine();
     let sin_wave: Vec<f32> = (0..seconds * sample_hz as usize)
         .map(|_| signal.next() as f32)
         .collect_vec();

--- a/sci-rs/benches/sosfiltfilt.rs
+++ b/sci-rs/benches/sosfiltfilt.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use dasp::{signal, Signal};
+use dasp_signal::{rate, Signal};
 use itertools::Itertools;
 use sci_rs::signal::filter::{design::Sos, sosfiltfilt_dyn};
 
@@ -51,7 +51,7 @@ fn butter_sosfiltfilt_100x(c: &mut Criterion) {
     // A signal with a frequency that we can recover
     let sample_hz = 1666.;
     let seconds = 10;
-    let mut signal = signal::rate(sample_hz).const_hz(25.).sine();
+    let mut signal = rate(sample_hz).const_hz(25.).sine();
     let sin_wave: Vec<f64> = (0..seconds * sample_hz as usize)
         .map(|_| signal.next())
         .collect_vec();
@@ -97,7 +97,7 @@ fn butter_sosfiltfilt_10x(c: &mut Criterion) {
     // A signal with a frequency that we can recover
     let sample_hz = 1666.;
     let seconds = 10;
-    let mut signal = signal::rate(sample_hz).const_hz(25.).sine();
+    let mut signal = rate(sample_hz).const_hz(25.).sine();
     let sin_wave: Vec<f64> = (0..seconds * sample_hz as usize)
         .map(|_| signal.next())
         .collect_vec();
@@ -143,7 +143,7 @@ fn butter_sosfiltfilt_f64(c: &mut Criterion) {
     // A signal with a frequency that we can recover
     let sample_hz = 1666.;
     let seconds = 10;
-    let mut signal = signal::rate(sample_hz).const_hz(25.).sine();
+    let mut signal = rate(sample_hz).const_hz(25.).sine();
     let sin_wave: Vec<f64> = (0..seconds * sample_hz as usize)
         .map(|_| signal.next())
         .collect_vec();
@@ -188,7 +188,7 @@ fn butter_sosfiltfilt_f32(c: &mut Criterion) {
     // A signal with a frequency that we can recover
     let sample_hz = 1666.;
     let seconds = 10;
-    let mut signal = signal::rate(sample_hz).const_hz(25.).sine();
+    let mut signal = rate(sample_hz).const_hz(25.).sine();
     let sin_wave: Vec<f32> = (0..seconds * sample_hz as usize)
         .map(|_| signal.next() as f32)
         .collect_vec();

--- a/sci-rs/src/signal/filter/sosfilt.rs
+++ b/sci-rs/src/signal/filter/sosfilt.rs
@@ -62,10 +62,7 @@ where
     YI: Iterator,
     YI::Item: Borrow<F>,
 {
-    SosFilt {
-        iter: y,
-        sos: *sos,
-    }
+    SosFilt { iter: y, sos: *sos }
 }
 
 #[inline]
@@ -98,7 +95,7 @@ where
 #[cfg(test)]
 mod tests {
     use approx::assert_relative_eq;
-    use dasp::{signal, Signal};
+    use dasp_signal::{rate, Signal};
     #[cfg(feature = "plot")]
     use gnuplot::Figure;
     use itertools::Itertools;
@@ -139,7 +136,7 @@ mod tests {
         // A signal with a frequency that we can recover
         let sample_hz = 1666.;
         let seconds = 10;
-        let mut signal = signal::rate(sample_hz).const_hz(25.).sine();
+        let mut signal = rate(sample_hz).const_hz(25.).sine();
         let sin_wave: Vec<f64> = (0..seconds * sample_hz as usize)
             .map(|_| signal.next())
             .collect_vec();

--- a/sci-rs/src/signal/filter/sosfiltfilt.rs
+++ b/sci-rs/src/signal/filter/sosfiltfilt.rs
@@ -58,7 +58,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use dasp::{signal, Signal};
+    use dasp_signal::{rate, Signal};
     #[cfg(feature = "plot")]
     use gnuplot::Figure;
     use itertools::Itertools;
@@ -99,7 +99,7 @@ mod tests {
         // A signal with a frequency that we can recover
         let sample_hz = 1666.;
         let seconds = 10;
-        let mut signal = signal::rate(sample_hz).const_hz(25.).sine();
+        let mut signal = rate(sample_hz).const_hz(25.).sine();
         let sin_wave: Vec<f64> = (0..seconds * sample_hz as usize)
             .map(|_| signal.next())
             .collect_vec();
@@ -165,7 +165,7 @@ mod tests {
         // A signal with a frequency that we can recover
         let sample_hz = 1666.;
         let seconds = 10;
-        let mut signal = signal::rate(sample_hz).const_hz(25.).sine();
+        let mut signal = rate(sample_hz).const_hz(25.).sine();
         let sin_wave: Vec<f32> = (0..seconds * sample_hz as usize)
             .map(|_| signal.next() as f32)
             .collect_vec();


### PR DESCRIPTION
This moves criterion into an optional dependency instead of a required dev dependency. This is a workaround for a feature gap of cargo.