### PR TITLE
Update savgol_filter to include deriv functionality

### DIFF
--- a/sci-rs/src/signal/filter/savgol_filter.rs
+++ b/sci-rs/src/signal/filter/savgol_filter.rs
@@ -40,8 +40,6 @@ where
         panic!("window_length is too small for the polynomials order")
     }
 
-    
-
     let mut fir = savgol_coeffs_dyn::<F>(window_length, polyorder, deriv, delta)
         .into_iter()
         .collect::<Vec<_>>();

--- a/sci-rs/src/signal/filter/savgol_filter.rs
+++ b/sci-rs/src/signal/filter/savgol_filter.rs
@@ -7,6 +7,12 @@ use nalgebra as na;
 use nalgebra::RealField;
 use num_traits::Float;
 
+//for testing
+#[cfg(feature = "std")]
+use std::io::Write;
+#[cfg(feature = "std")]
+use std::fs::OpenOptions;
+
 #[cfg(feature = "alloc")]
 use alloc::vec;
 #[cfg(feature = "alloc")]
@@ -20,7 +26,7 @@ use alloc::vec::Vec;
 ///
 /// Design coefficients for a Savitzky-Golay filter and convolve with data using nearest edge padding.
 ///
-pub fn savgol_filter_dyn<YI, F>(y: YI, window_length: usize, polyorder: usize) -> Vec<F>
+pub fn savgol_filter_dyn<YI, F>(y: YI, window_length: usize, polyorder: usize, deriv: usize, delta: F) -> Vec<F>
 where
     F: RealField + Copy + Sum,
     YI: Iterator,
@@ -34,10 +40,12 @@ where
         panic!("window_length is too small for the polynomials order")
     }
 
-    let fir = savgol_coeffs_dyn::<f64>(window_length, polyorder)
+    let mut fir = savgol_coeffs_dyn::<F>(window_length, polyorder, deriv, delta)
         .into_iter()
-        .map(|f| F::from_f64(f).unwrap())
+        .map(|f| f)
         .collect::<Vec<_>>();
+
+    fir.reverse();
 
     // Pad with nearest edge value
     let size_hint = y.size_hint();
@@ -47,7 +55,7 @@ where
         return vec![];
     };
     let nearest = *nearest.borrow();
-    data.extend((0..window_length / 2).map(|_| nearest));
+    data.extend((0..(window_length / 2 + 1)).map(|_| nearest));
     data.extend(y.map(|yi| *yi.borrow()));
     let nearest = *data.last().unwrap();
     data.extend((0..window_length / 2).map(|_| nearest));
@@ -61,6 +69,8 @@ where
     rslt
 }
 
+
+
 ///
 /// Design 1-D Savitzky-Golay filter coefficients
 ///
@@ -69,7 +79,7 @@ where
 /// This function is sensitive to f64 and f32 primitives due to use of least squares.
 /// The coefficients may go to zero for higher order polynomials and larger window lengths.
 ///
-pub fn savgol_coeffs_dyn<F>(window_length: usize, polyorder: usize) -> Vec<F>
+pub fn savgol_coeffs_dyn<F>(window_length: usize, polyorder: usize, deriv: usize, delta: F) -> Vec<F>
 where
     F: RealField + Copy,
 {
@@ -83,23 +93,29 @@ where
     let pos = if rem == 0 {
         let f = F::from_f32(0.5).unwrap();
         (0..window_length)
-            .map(|i| (F::from_usize(i).unwrap() + f - half_window))
+            .map(|i| (half_window - F::from_usize(i).unwrap() - f))
             .collect::<Vec<_>>()
     } else {
         (0..window_length)
-            .map(|i| F::from_usize(i).unwrap() - half_window)
+            .map(|i| half_window - F::from_usize(i).unwrap())
             .collect::<Vec<_>>()
     };
+
+
+    if deriv > polyorder {
+        let mut ret = vec![F::zero(); window_length];
+        return ret
+    }
 
     // Columns are 2m+1 integer positions centered on 0
     // Rows are powers of positions from 0 to polyorder
     // Setting up a Vandermonde matrix for solving A * coeffs = y
     #[allow(non_snake_case)]
     let A = na::DMatrix::<F>::from_fn(polyorder + 1, window_length, |i, j| pos[j].powi(i as i32));
-    let y = na::DVector::<F>::from_fn(
+    let mut y = na::DVector::<F>::from_fn(
         polyorder + 1,
         |i, _| {
-            if i == 0 {
+            if i == deriv {
                 F::one()
             } else {
                 F::zero()
@@ -107,9 +123,15 @@ where
         },
     );
 
+    y[deriv] = (F::from_usize(factorial(deriv)).unwrap()) / delta.powi(deriv as i32);
+
     // Solve the system for the Savitsky-Golay FIR coefficients
     let solve = lstsq::lstsq(&A, &y, F::from_f32(1e-9).unwrap()).unwrap();
     solve.solution.data.into()
+}
+
+fn factorial(n: usize) -> usize {
+    (1..=n).product()
 }
 
 #[cfg(test)]
@@ -120,37 +142,109 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     pub fn can_filter() {
-        let v = savgol_filter_dyn((0..100).map(|i| i as f32), 11, 2);
+        let v = savgol_filter_dyn((0..100).map(|i| i as f32), 11, 2, 0, 1.0);
         println!("v = {:?}", v);
 
-        let v = savgol_filter_dyn((0..0).map(|i| i as f32), 11, 2);
+        let v = savgol_filter_dyn((0..0).map(|i| i as f32), 11, 2, 0, 1.0);
         println!("v = {:?}", v);
+
+        let actual_coeff = savgol_coeffs_dyn::<f64>(5, 2, 0, 1.0);
+        println!("coeffs = {:?}", actual_coeff);
+        let input = [2.0, 2.0, 5.0, 2.0, 1.0, 0.0, 1.0, 4.0, 9.0];
+        let actual = savgol_filter_dyn(input.iter(), 5, 2, 0, 1.0);
+        println!("actual = {:?}", actual);
+        let expected = [1.74285714, 3.02857143, 3.54285714, 2.85714286, 0.65714286, 0.17142857, 1.0, 4.6, 7.97142857];
+        assert_eq!(actual.len(), expected.len());
+        for (a, e) in actual.iter().zip(expected.iter()) {
+            assert_relative_eq!(a, e, max_relative = 1e-5);
+        }
+
+        let actual_coeff = savgol_coeffs_dyn::<f64>(5, 2, 1, 1.0);
+        println!("coeffs = {:?}", actual_coeff);
+        let input = [2.0, 2.0, 5.0, 2.0, 1.0, 0.0, 1.0, 4.0, 9.0];
+        let actual = savgol_filter_dyn(input.iter(), 5, 2, 1, 1.0);
+        println!("actual = {:?}", actual);
+        let expected = [0.6, 0.3, -0.2, -0.8, -1.0, 0.4, 2.0, 2.6, 2.1];
+        assert_eq!(actual.len(), expected.len());
+        for (a, e) in actual.iter().zip(expected.iter()) {
+            assert_relative_eq!(a, e, max_relative = 1e-5);
+        }
+
+        let input = (0..100).map(|i| (3*i - 2) as f64); //y = 3x - 2
+        let actual = savgol_filter_dyn(input, 51, 5, 0, 1.0);
+        let expected = [2.45650177,   4.06008889,   5.86936071,   7.87987343,
+                        10.08430349,  12.47257185,  15.03201779,  17.74762253,
+                        20.6022825 ,  23.57713222,  26.65191695,  29.805415  ,
+                        33.01590968,  36.26171099,  39.52172696,  42.77608466,
+                        46.00680095,  49.19850285,  52.33919758,  55.4210924 ,
+                        58.44146398,  61.40357756,  64.31765571,  67.20189688,
+                        70.08354354,  73.        ,  76.        ,  79.        ,
+                        82.        ,  85.        ,  88.        ,  91.        ,
+                        94.        ,  97.        , 100.        , 103.        ,
+                        106.        , 109.        , 112.        , 115.        ,
+                        118.        , 121.        , 124.        , 127.        ,
+                        130.        , 133.        , 136.        , 139.        ,
+                        142.        , 145.        , 148.        , 151.        ,
+                        154.        , 157.        , 160.        , 163.        ,
+                        166.        , 169.        , 172.        , 175.        ,
+                        178.        , 181.        , 184.        , 187.        ,
+                        190.        , 193.        , 196.        , 199.        ,
+                        202.        , 205.        , 208.        , 211.        ,
+                        214.        , 217.        , 220.        , 222.91645647,
+                        225.79810312, 228.6823443 , 231.59642245, 234.55853602,
+                        237.5789076 , 240.66080242, 243.80149716, 246.99319905,
+                        250.22391534, 253.47827305, 256.73828901, 259.98409032,
+                        263.194585  , 266.34808305, 269.42286778, 272.3977175 ,
+                        275.25237747, 277.96798222, 280.52742816, 282.91569651,
+                        285.12012658, 287.13063929, 288.93991111, 290.54349823];
+
+        assert_eq!(actual.len(), expected.len());
+        for (a, e) in actual.iter().zip(expected.iter()) {
+            assert_relative_eq!(a, e, max_relative = 1e-5);
+        }
     }
 
     #[test]
     pub fn can_coeffs() {
-        let actual = savgol_coeffs_dyn::<f32>(5, 2);
+        let actual = savgol_coeffs_dyn::<f32>(5, 2, 0, 1.0);
         let expected = [-0.08571429, 0.34285714, 0.48571429, 0.34285714, -0.08571429];
         assert_eq!(actual.len(), expected.len());
         for (a, e) in actual.iter().zip(expected.iter()) {
             assert_relative_eq!(a, e, max_relative = 1e-5);
         }
 
-        let actual = savgol_coeffs_dyn::<f64>(5, 2);
+        let actual = savgol_coeffs_dyn::<f64>(5, 2, 0, 1.0);
         let expected = [-0.08571429, 0.34285714, 0.48571429, 0.34285714, -0.08571429];
         assert_eq!(actual.len(), expected.len());
         for (a, e) in actual.iter().zip(expected.iter()) {
             assert_relative_eq!(a, e, max_relative = 1e-7);
         }
 
-        let actual = savgol_coeffs_dyn::<f64>(4, 2);
+        let actual = savgol_coeffs_dyn::<f64>(4, 2, 0, 1.0);
         let expected = [-0.0625, 0.5625, 0.5625, -0.0625];
         assert_eq!(actual.len(), expected.len());
         for (a, e) in actual.iter().zip(expected.iter()) {
             assert_relative_eq!(a, e, max_relative = 1e-7);
         }
 
-        let actual = savgol_coeffs_dyn::<f64>(21, 8);
+        let actual = savgol_coeffs_dyn::<f64>(51, 5, 0, 1.0);
+        let expected = [0.02784785,  0.01160327, -0.00086484, -0.00994566, -0.01601181,
+                        -0.01941934, -0.02050775, -0.01959997, -0.01700239, -0.0130048 ,
+                        -0.00788047, -0.00188609,  0.00473822,  0.01176888,  0.01899888,
+                        0.02623777,  0.03331167,  0.04006325,  0.04635174,  0.05205294,
+                        0.05705919,  0.06127943,  0.06463912,  0.0670803 ,  0.06856157,
+                        0.06905808,  0.06856157,  0.0670803 ,  0.06463912,  0.06127943,
+                        0.05705919,  0.05205294,  0.04635174,  0.04006325,  0.03331167,
+                        0.02623777,  0.01899888,  0.01176888,  0.00473822, -0.00188609,
+                        -0.00788047, -0.0130048 , -0.01700239, -0.01959997, -0.02050775,
+                        -0.01941934, -0.01601181, -0.00994566, -0.00086484,  0.01160327,
+                        0.02784785];
+        assert_eq!(actual.len(), expected.len());
+        for (a, e) in actual.iter().zip(expected.iter()) {
+            assert_relative_eq!(a, e, max_relative = 5e-6);
+        }
+
+        let actual = savgol_coeffs_dyn::<f64>(21, 8, 0, 1.0);
         let expected = [
             0.0125937,
             -0.04897551,
@@ -177,6 +271,64 @@ mod tests {
         assert_eq!(actual.len(), expected.len());
         for (a, e) in actual.iter().zip(expected.iter()) {
             assert_relative_eq!(a, e, max_relative = 1e-6);
+        }
+
+        //deriv tests
+        let actual = savgol_coeffs_dyn::<f64>(5, 2, 1, 1.0);
+        let expected = [ 2.0e-1,  1.0e-1,  2.07548111e-16, -1.0e-1, -2.0e-1];
+        assert_eq!(actual.len(), expected.len());
+        for (a, e) in actual.iter().zip(expected.iter()) {
+            assert_relative_eq!(a, e, max_relative = 1e-7);
+        }
+
+        let actual = savgol_coeffs_dyn::<f64>(6, 3, 1, 1.0);
+        let expected = [
+            -0.09093915,
+            0.4130291,
+            0.21560847,
+            -0.21560847,
+            -0.4130291,
+            0.09093915
+        ];
+        assert_eq!(actual.len(), expected.len());
+        for (a, e) in actual.iter().zip(expected.iter()) {
+            assert_relative_eq!(a, e, max_relative = 1e-7);
+        }
+
+        let actual = savgol_coeffs_dyn::<f64>(6, 3, 2, 1.0);
+        let expected = [
+            0.17857143,
+            -0.03571429,
+            -0.14285714,
+            -0.14285714,
+            -0.03571429,
+            0.17857143
+        ];
+        assert_eq!(actual.len(), expected.len());
+        for (a, e) in actual.iter().zip(expected.iter()) {
+            assert_relative_eq!(a, e, max_relative = 5e-6);
+        }
+
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    pub fn write_to_file() {
+        //credit to https://stackoverflow.com/questions/31192956/whats-the-de-facto-way-of-reading-and-writing-files-in-rust-1-x
+        //for file I/O code
+        let mut f = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open("./output.txt")
+        .expect("Unable to open file");
+
+        let data = (0..100).map(|i| (3*i - 2) as f64); //y = 3x - 2
+        f.write_all(format!("{:?}\n", data.clone().collect::<Vec<_>>()).as_bytes()).expect("Unable to write file");
+        
+        for i in 0..3 {
+            let temp = data.clone();
+            let actual = savgol_filter_dyn(temp, 51, 5, i, 1.0);
+            f.write_all(format!("{:?}\n", actual).as_bytes()).expect("Unable to write file");
         }
     }
 }


### PR DESCRIPTION
This expands the functionality of the savgol_filter_dyn method to include the differentiation capability that the original [sci_py method](https://github.com/scipy/scipy/blob/main/scipy/signal/_savitzky_golay.py#L8-L144) has. This addition allows for the possibility of taking a derivative of a signal as it is convolved with the Savitsky-Golay filter. The [Wikipedia page](https://en.m.wikipedia.org/wiki/Savitzky%E2%80%93Golay_filter) has a good summary of the math involved, along with high quality visualizations.

This update also includes several more unit tests for the savgol_filter_dyn and savgol_coeffs_dyn methods and fixes an off by one error in the padding before convolution of savgol_filter_dyn.

A demonstration of different numbers of derivatives for fixed input is given below.
![image](https://github.com/user-attachments/assets/b251e193-d398-424a-b765-3e5519a11bda)

I'm looking for confirmation that everything seems documented properly, since this is my first addition to sci-rs. Let me know what you think @trueb2 
