### PR TITLE
v0.4.0: Bump crate versions

### DIFF
--- a/sci-rs/Cargo.toml
+++ b/sci-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sci-rs"
-version = "0.3.16"
+version = "0.4.0"
 edition = "2021"
 authors = ["Jacob Trueb <jtrueb@northwestern.edu>"]
 description = "Rust scientific analysis library similar to SciPy"
@@ -22,12 +22,12 @@ std = ['nalgebra/std', 'nalgebra/macros', 'rustfft', 'alloc']
 
 [dependencies]
 num-traits = { version = "0.2.15", default-features = false }
-itertools = { version = "0.12.0", default-features = false }
-nalgebra = { version = "0.32.2", default-features = false }
+itertools = { version = "0.13.0", default-features = false }
+nalgebra = { version = "0.33.2", default-features = false }
 ndarray = { version = "0.16.1", default-features = false }
-lstsq = { version = "0.5.0", default-features = false }
+lstsq = { version = "0.6.0", default-features = false }
 rustfft = { version = "6.1.0", features = ["neon"], optional = true }
-kalmanfilt = { version = "0.2.4", default-features = false }
+kalmanfilt = { version = "0.3.0", default-features = false }
 gaussfilt = { version = "0.1.3", default-features = false }
 
 [dev-dependencies]

--- a/sci-rs/src/linalg/companion.rs
+++ b/sci-rs/src/linalg/companion.rs
@@ -14,7 +14,7 @@ where
     T: Scalar + One + Zero + Div<Output = T> + Neg<Output = T> + Copy,
     B: Borrow<T>,
     I: Iterator<Item = B>,
-    DefaultAllocator: Allocator<T, Dyn, Dyn>,
+    DefaultAllocator: Allocator<Dyn, Dyn>,
 {
     let mut itr = itr;
     let a0: T = *itr.next().expect("Invalid data length").borrow();
@@ -26,7 +26,7 @@ where
         T,
         Dyn,
         Dyn,
-        <DefaultAllocator as allocator::Allocator<T, Dyn, Dyn>>::Buffer,
+        <DefaultAllocator as allocator::Allocator<Dyn, Dyn>>::Buffer<T>,
     >::zeros(m - 1, m - 1);
     for (i, t) in itr {
         unsafe {

--- a/sci-rs/src/signal/filter/ext.rs
+++ b/sci-rs/src/signal/filter/ext.rs
@@ -34,7 +34,7 @@ where
     T: Scalar + Copy + Zero + One + Sub<Output = T>,
     M: Dim,
     N: Dim,
-    DefaultAllocator: Allocator<T, M, N> + Allocator<T, Dyn, Dyn>,
+    DefaultAllocator: Allocator<M, N> + Allocator<Dyn, Dyn>,
 {
     if matches!(padtype, Pad::None) {
         padlen = Some(0);
@@ -61,10 +61,9 @@ where
                 nalgebra::Dyn,
                 nalgebra::Dyn,
                 <nalgebra::DefaultAllocator as nalgebra::allocator::Allocator<
-                    T,
                     nalgebra::Dyn,
                     nalgebra::Dyn,
-                >>::Buffer,
+                >>::Buffer<T>,
             >::from_iterator(x.shape().0, x.shape().1, x.into_iter().cloned()),
         );
     }
@@ -77,10 +76,9 @@ where
                 nalgebra::Dyn,
                 nalgebra::Dyn,
                 <nalgebra::DefaultAllocator as nalgebra::allocator::Allocator<
-                    T,
                     nalgebra::Dyn,
                     nalgebra::Dyn,
-                >>::Buffer,
+                >>::Buffer<T>,
             >::from_iterator(x.shape().0, x.shape().1, x.into_iter().cloned()),
         );
     }
@@ -99,7 +97,7 @@ where
     T: Scalar + Copy + Zero + One + Sub<Output = T>,
     M: Dim,
     N: Dim,
-    DefaultAllocator: Allocator<T, M, N> + Allocator<T, Dyn, Dyn>,
+    DefaultAllocator: Allocator<M, N> + Allocator<Dyn, Dyn>,
 {
     //TODO: Figure out the ndarray situation
     assert!(axis < 2);
@@ -110,10 +108,9 @@ where
             nalgebra::Dyn,
             nalgebra::Dyn,
             <nalgebra::DefaultAllocator as nalgebra::allocator::Allocator<
-                T,
                 nalgebra::Dyn,
                 nalgebra::Dyn,
-            >>::Buffer,
+            >>::Buffer<T>,
         >::from_iterator(x.shape().0, x.shape().1, x.into_iter().cloned());
     }
 
@@ -130,10 +127,9 @@ where
                 nalgebra::Dyn,
                 nalgebra::Dyn,
                 <nalgebra::DefaultAllocator as nalgebra::allocator::Allocator<
-                    T,
                     nalgebra::Dyn,
                     nalgebra::Dyn,
-                >>::Buffer,
+                >>::Buffer<T>,
             >::zeros(new_rows, new_columns);
 
             // 2 * left_end - left_ext
@@ -182,10 +178,9 @@ where
                 nalgebra::Dyn,
                 nalgebra::Dyn,
                 <nalgebra::DefaultAllocator as nalgebra::allocator::Allocator<
-                    T,
                     nalgebra::Dyn,
                     nalgebra::Dyn,
-                >>::Buffer,
+                >>::Buffer<T>,
             >::zeros(new_rows, new_columns);
 
             // 2 * left_end - left_ext

--- a/sci-rs/src/signal/filter/lfilter_zi.rs
+++ b/sci-rs/src/signal/filter/lfilter_zi.rs
@@ -1,5 +1,5 @@
 use core::{iter::Sum, ops::SubAssign};
-use nalgebra::{ClosedAdd, ClosedMul, DMatrix, OMatrix, RealField, SMatrix, Scalar};
+use nalgebra::{DMatrix, OMatrix, RealField, SMatrix, Scalar};
 use num_traits::{Float, One, Zero};
 
 use crate::linalg::companion_dyn;
@@ -26,7 +26,7 @@ use alloc::vec::Vec;
 #[inline]
 pub fn lfilter_zi_dyn<F>(b: &[F], a: &[F]) -> Vec<F>
 where
-    F: RealField + Copy + PartialEq + Scalar + Zero + One + ClosedMul + ClosedAdd + Sum + SubAssign,
+    F: RealField + Copy + PartialEq + Scalar + Zero + One + Sum + SubAssign,
 {
     assert!(b.len() == a.len());
     let m = b.len();

--- a/sci-rs/src/signal/filter/sosfilt_zi.rs
+++ b/sci-rs/src/signal/filter/sosfilt_zi.rs
@@ -1,5 +1,5 @@
 use core::{iter::Sum, ops::SubAssign};
-use nalgebra::{ClosedAdd, ClosedMul, RealField, Scalar};
+use nalgebra::{RealField, Scalar};
 use num_traits::{Float, One, Zero};
 
 use crate::signal::filter::lfilter_zi_dyn;
@@ -24,7 +24,7 @@ use alloc::vec::Vec;
 ///
 pub fn sosfilt_zi_dyn<'a, F, I, S>(s: I)
 where
-    F: RealField + Copy + PartialEq + Scalar + Zero + One + ClosedMul + ClosedAdd + Sum + SubAssign,
+    F: RealField + Copy + PartialEq + Scalar + Zero + One + Sum + SubAssign,
     I: Iterator<Item = &'a mut Sos<F>>,
 {
     let mut scale = F::one();

--- a/sci-rs/src/signal/filter/sosfiltfilt.rs
+++ b/sci-rs/src/signal/filter/sosfiltfilt.rs
@@ -1,5 +1,5 @@
 use core::{borrow::Borrow, cmp::min, iter::Sum, ops::SubAssign};
-use nalgebra::{ClosedAdd, ClosedMul, DVector, RealField, Scalar};
+use nalgebra::{DVector, RealField, Scalar};
 use num_traits::{Float, One, Zero};
 
 use super::{design::Sos, pad, sosfilt_dyn, sosfilt_zi_dyn, Pad};
@@ -16,7 +16,7 @@ use alloc::vec::Vec;
 #[inline]
 pub fn sosfiltfilt_dyn<YI, F>(y: YI, sos: &[Sos<F>]) -> Vec<F>
 where
-    F: RealField + Copy + PartialEq + Scalar + Zero + One + ClosedMul + ClosedAdd + Sum + SubAssign,
+    F: RealField + Copy + PartialEq + Scalar + Zero + One + Sum + SubAssign,
     YI: Iterator,
     YI::Item: Borrow<F>,
 {


### PR DESCRIPTION
This bumps the crate and dependency versions. 

Notably, nalgebra moved the generic T from the Allocator to the Buffer type.