### PR TITLE
Cheb_dyn

### DIFF
--- a/sci-rs/src/signal/filter/design/iirfilter.rs
+++ b/sci-rs/src/signal/filter/design/iirfilter.rs
@@ -283,6 +283,95 @@ where
     ZpkFormatFilter { z, p, k }
 }
 
+/// Chebyshev type I digital and analog filter design.
+///
+/// Design an Nth-order digital or analog Chebyshev type I filter and
+/// return the filter coefficients.
+///
+/// Parameters
+/// ----------
+/// * `N` : int  
+///     The order of the filter.
+/// * `rp` : float  
+///     The maximum ripple allowed below unity gain in the passband.
+///     Specified in decibels, as a positive number.
+/// * `Wn` : array_like  
+///     A scalar or length-2 sequence giving the critical frequencies.
+///     For Type I filters, this is the point in the transition band at which
+///     the gain first drops below -`rp`.
+///
+///     For digital filters, `Wn` are in the same units as `fs`. By default,
+///     `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
+///     where 1 is the Nyquist frequency. (`Wn` is thus in
+///     half-cycles / sample.)
+///
+///     For analog filters, `Wn` is an angular frequency (e.g., rad/s).
+/// * `btype` : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional  
+///     The type of filter.  Default is 'lowpass'.
+/// * `analog` : bool, optional  
+///     When True, return an analog filter, otherwise a digital filter is
+///     returned.
+/// * `output` : {'ba', 'zpk', 'sos'}, optional  
+///     Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
+///     second-order sections ('sos'). Default is 'ba' for backwards
+///     compatibility, but 'sos' should be used for general-purpose filtering.
+/// * `fs` : float, optional  
+///     The sampling frequency of the digital system.
+///
+/// Returns
+/// -------
+/// b, a : ndarray, ndarray  
+///     Numerator (`b`) and denominator (`a`) polynomials of the IIR filter.
+///     Only returned if ``output='ba'``.
+/// z, p, k : ndarray, ndarray, float  
+///     Zeros, poles, and system gain of the IIR filter transfer
+///     function.  Only returned if ``output='zpk'``.
+/// sos : ndarray  
+///     Second-order sections representation of the IIR filter.
+///     Only returned if ``output='sos'``.
+///
+/// See Also
+/// --------
+/// cheb1ord, [cheb1ap_dyn]
+///
+/// Notes
+/// -----
+/// The Chebyshev type I filter maximizes the rate of cutoff between the
+/// frequency response's passband and stopband, at the expense of ripple in
+/// the passband and increased ringing in the step response.
+///
+/// Type I filters roll off faster than Type II (`cheby2`), but Type II
+/// filters do not have any ripple in the passband.
+///
+/// The equiripple passband has N maxima or minima (for example, a
+/// 5th-order filter has 3 maxima and 2 minima). Consequently, the DC gain is
+/// unity for odd-order filters, or -rp dB for even-order filters.
+#[cfg(feature = "alloc")]
+pub fn cheby1_dyn<F>(
+    n: usize,
+    rp: F,
+    wn: Vec<F>,
+    btype: Option<FilterBandType>,
+    analog: Option<bool>,
+    output: Option<FilterOutputType>,
+    fs: Option<F>,
+) -> DigitalFilter<F>
+where
+    F: RealField + Float + Sum,
+{
+    iirfilter_dyn(
+        n,
+        wn,
+        Some(rp),
+        None, // rs
+        btype,
+        Some(FilterType::ChebyshevI),
+        analog,
+        output,
+        fs,
+    )
+}
+
 /// Return (z,p,k) for Nth-order Chebyshev type II analog lowpass filter.
 ///
 /// The returned filter prototype has attenuation of at least ``rs`` decibels

--- a/sci-rs/src/signal/filter/design/iirfilter.rs
+++ b/sci-rs/src/signal/filter/design/iirfilter.rs
@@ -440,6 +440,90 @@ where
     ZpkFormatFilter { z, p, k }
 }
 
+/// Chebyshev type II digital and analog filter design.
+///
+/// Design an Nth-order digital or analog Chebyshev type II filter and
+/// return the filter coefficients.
+///
+/// Parameters
+/// ----------
+/// * `N` : int  
+///     The order of the filter.
+/// * `rs` : float  
+///     The minimum attenuation required in the stop band.
+///     Specified in decibels, as a positive number.
+/// * `Wn` : array_like  
+///     A scalar or length-2 sequence giving the critical frequencies.
+///     For Type II filters, this is the point in the transition band at which
+///     the gain first reaches -`rs`.
+///
+///     For digital filters, `Wn` are in the same units as `fs`. By default,
+///     `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
+///     where 1 is the Nyquist frequency. (`Wn` is thus in
+///     half-cycles / sample.)
+///
+///     For analog filters, `Wn` is an angular frequency (e.g., rad/s).
+/// * `btype` : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional  
+///     The type of filter.  Default is 'lowpass'.
+/// * `analog` : bool, optional  
+///     When True, return an analog filter, otherwise a digital filter is
+///     returned.
+/// * `output` : {'ba', 'zpk', 'sos'}, optional  
+///     Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
+///     second-order sections ('sos'). Default is 'ba' for backwards
+///     compatibility, but 'sos' should be used for general-purpose filtering.
+/// * `fs` : float, optional  
+///     The sampling frequency of the digital system.
+///
+/// Returns
+/// -------
+/// b, a : ndarray, ndarray
+///     Numerator (`b`) and denominator (`a`) polynomials of the IIR filter.
+///     Only returned if ``output='ba'``.
+/// z, p, k : ndarray, ndarray, float
+///     Zeros, poles, and system gain of the IIR filter transfer
+///     function.  Only returned if ``output='zpk'``.
+/// sos : ndarray
+///     Second-order sections representation of the IIR filter.
+///     Only returned if ``output='sos'``.
+///
+/// See Also
+/// --------
+/// cheb2ord, [cheb2ap_dyn]
+///
+/// Notes
+/// -----
+/// The Chebyshev type II filter maximizes the rate of cutoff between the
+/// frequency response's passband and stopband, at the expense of ripple in
+/// the stopband and increased ringing in the step response.
+///
+/// Type II filters do not roll off as fast as Type I (`cheby1`).
+#[cfg(feature = "alloc")]
+pub fn cheby2_dyn<F>(
+    n: usize,
+    rs: F,
+    wn: Vec<F>,
+    btype: Option<FilterBandType>,
+    analog: Option<bool>,
+    output: Option<FilterOutputType>,
+    fs: Option<F>,
+) -> DigitalFilter<F>
+where
+    F: RealField + Float + Sum,
+{
+    iirfilter_dyn(
+        n,
+        wn,
+        None, // rp
+        Some(rs),
+        btype,
+        Some(FilterType::ChebyshevII),
+        analog,
+        output,
+        fs,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use approx::assert_relative_eq;


### PR DESCRIPTION
This adds the functions cheb1 and cheb2 necessary
for decimate in a manner that is not as obstructive 
as what firwin had set out to achieve.

More functions to come as they are made.