### PR TITLE
Update Comb to Trait

### DIFF
--- a/sci-rs/src/special/combinatorics.rs
+++ b/sci-rs/src/special/combinatorics.rs
@@ -1,24 +1,70 @@
 use nalgebra::min;
 use num_traits::{FromPrimitive, PrimInt};
 
-/// The number of combinations of `n` taken `k` at a time.
-///
-/// This is also known as $n$ choose $k$ and is generally given by the formula
-/// $$
-/// \begin{pmatrix}
-/// n \\\\ k
-/// \end{pmatrix} = \frac{n!}{k!(n-k)!}
-/// $$
-///
-/// # Examples
-/// ```
-/// use sci_rs::special::comb;
-/// assert_eq!(comb(5, 2), 10);
-/// ```
-///
-/// # Notes
-/// When `n < 0` or `k < 0` or `n < k`, then `0` is returned.
-pub fn comb<Int>(n: Int, k: Int) -> Int
+/// Various combinatorics functions for integer types.
+pub trait Comb {
+    /// The number of combinations of `n` taken `k` at a time.
+    ///
+    /// This is also known as $n$ choose $k$ and is generally given by the formula
+    /// $$
+    /// \begin{pmatrix}
+    /// n \\\\ k
+    /// \end{pmatrix} = \frac{n!}{k!(n-k)!}
+    /// $$
+    ///
+    /// # Examples
+    /// ```
+    /// use sci_rs::special::Comb;
+    /// assert_eq!(5_i32.comb(2), 10);
+    /// ```
+    ///
+    /// # Notes
+    /// When `n < 0` or `k < 0` or `n < k`, then `0` is returned.
+    fn comb(self, k: Self) -> Self;
+
+    /// Number of combinations with repetition.
+    ///
+    /// The number of combinations of `n` taken `k` at a time with repetition. This is also known as a
+    /// `k`-combination with repetition or `k`-multicombinations. For a more detailed explanation, see
+    /// the [wiki] page.
+    ///
+    /// # Examples
+    /// ```
+    /// use sci_rs::special::Comb;
+    /// assert_eq!(5_i32.comb_rep(2), 15);
+    /// assert_eq!(10_i32.comb_rep(3), 220);
+    /// ```
+    ///
+    /// # Notes
+    /// When `n < 0` or `k < 0` or `n < k`, then `0` is returned.
+    ///
+    /// # References
+    /// - [Wikipedia][wiki]
+    ///
+    /// [wiki]: https://en.wikipedia.org/wiki/Combination#Number_of_combinations_with_repetition
+    fn comb_rep(self, k: Self) -> Self;
+}
+
+macro_rules! comb_primint_impl {
+    ($($T: ty)*) => ($(
+        impl Comb for $T {
+            #[inline(always)]
+            fn comb(self, k: Self) -> Self {
+                primint_comb(self, k)
+            }
+
+            #[inline(always)]
+            fn comb_rep(self, k: Self) -> Self {
+                primint_comb_rep(self, k)
+            }
+
+        }
+    )*)
+}
+
+comb_primint_impl! {u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize}
+
+fn primint_comb<Int>(n: Int, k: Int) -> Int
 where
     Int: PrimInt + FromPrimitive,
 {
@@ -32,31 +78,11 @@ where
     })
 }
 
-/// Number of combinations with repetition.
-///
-/// The number of combinations of `n` taken `k` at a time with repetition. This is also known as a
-/// `k`-combination with repetition or `k`-multicombinations. For a more detailed explanation, see
-/// the [wiki] page.
-///
-/// # Examples
-/// ```
-/// use sci_rs::special::comb_rep;
-/// assert_eq!(comb_rep(5, 2), 15);
-/// assert_eq!(comb_rep(10, 3), 220);
-/// ```
-///
-/// # Notes
-/// When `n < 0` or `k < 0` or `n < k`, then `0` is returned.
-///
-/// # References
-/// - [Wikipedia][wiki]
-///
-/// [wiki]: https://en.wikipedia.org/wiki/Combination#Number_of_combinations_with_repetition
-pub fn comb_rep<Int>(n: Int, k: Int) -> Int
+fn primint_comb_rep<Int>(n: Int, k: Int) -> Int
 where
     Int: PrimInt + FromPrimitive,
 {
-    comb(n + k - Int::one(), k)
+    primint_comb(n + k - Int::one(), k)
 }
 
 #[cfg(test)]
@@ -76,26 +102,26 @@ mod tests {
 
     #[test]
     fn choose() {
-        assert_eq!(comb(3_u8, 1), 3);
-        assert_eq!(comb(3_u8, 2), 3);
-        assert_eq!(comb(3_u8, 3), 1);
+        assert_eq!(3_u8.comb(1), 3);
+        assert_eq!(3_u8.comb(2), 3);
+        assert_eq!(3_u8.comb(3), 1);
 
         const REF_VALUES_5: [i32; 7] = [1, 5, 10, 10, 5, 1, 0];
         const REF_VALUES_10: [i32; 12] = [1, 10, 45, 120, 210, 252, 210, 120, 45, 10, 1, 0];
         const REF_VALUES_15: [i32; 16] = [
             1, 15, 105, 455, 1365, 3003, 5005, 6435, 6435, 5005, 3003, 1365, 455, 105, 15, 1,
         ];
-        check_values(5, &REF_VALUES_5, comb);
-        check_values(10, &REF_VALUES_10, comb);
-        check_values(15, &REF_VALUES_15, comb);
+        check_values(5, &REF_VALUES_5, i32::comb);
+        check_values(10, &REF_VALUES_10, i32::comb);
+        check_values(15, &REF_VALUES_15, i32::comb);
     }
 
     #[test]
     fn choose_negatives() {
         for n in -10..-1 {
             for m in -5..5 {
-                assert_eq!(comb(n, m), 0);
-                assert_eq!(comb(m, n), 0);
+                assert_eq!(n.comb(m), 0);
+                assert_eq!(m.comb(n), 0);
             }
         }
     }
@@ -104,14 +130,14 @@ mod tests {
     fn choose_greater_than() {
         for i in 0..10 {
             for j in 0..i {
-                assert_eq!(comb(j, i), 0);
+                assert_eq!(j.comb(i), 0);
             }
         }
     }
 
     #[test]
     fn zero_choose_zero() {
-        assert_eq!(comb(0, 0), 1);
+        assert_eq!(0.comb(0), 1);
     }
 
     #[test]
@@ -122,17 +148,17 @@ mod tests {
             1, 10, 55, 220, 715, 2002, 5005, 11440, 24310, 48620, 92378, 167960, 293930, 497420,
             817190,
         ];
-        check_values(5, &REF_VALUES_5, comb_rep);
-        check_values(7, &REF_VALUES_7, comb_rep);
-        check_values(10, &REF_VALUES_10, comb_rep);
+        check_values(5, &REF_VALUES_5, i32::comb_rep);
+        check_values(7, &REF_VALUES_7, i32::comb_rep);
+        check_values(10, &REF_VALUES_10, i32::comb_rep);
     }
 
     #[test]
     fn choose_replacement_negatives() {
         for n in -10..-1 {
             for m in -5..5 {
-                assert_eq!(comb_rep(n, m), 0);
-                assert_eq!(comb_rep(m, n), 0);
+                assert_eq!(n.comb_rep(m), 0);
+                assert_eq!(m.comb_rep(n), 0);
             }
         }
     }
@@ -141,7 +167,7 @@ mod tests {
     fn choose_zero_replacement() {
         for i in 0..1 {
             for j in 0..1 {
-                assert_eq!(comb_rep(i, j), i);
+                assert_eq!(i.comb_rep(j), i);
             }
         }
     }

--- a/sci-rs/src/special/combinatorics.rs
+++ b/sci-rs/src/special/combinatorics.rs
@@ -139,6 +139,9 @@ fn primint_comb_rep<Int>(n: Int, k: Int) -> Int
 where
     Int: PrimInt + FromPrimitive,
 {
+    if n + k == Int::zero() {
+        return Int::zero();
+    }
     primint_comb(n + k - Int::one(), k)
 }
 
@@ -184,14 +187,16 @@ mod tests {
     use super::*;
     use core::fmt;
 
-    fn check_values<T>(ref_values: &[[T; 10]], func: fn(T, T) -> T)
+    fn check_values<K, T>(ref_values: &[[K;10]], func: fn(T, T) -> T)
     where
+        K: PrimInt + FromPrimitive, 
         T: PrimInt + FromPrimitive + fmt::Debug,
     {
         for (n, &elements) in ref_values.iter().enumerate() {
             for (k, &val) in elements.iter().enumerate() {
                 let n = T::from_usize(n).unwrap();
                 let k = T::from_usize(k).unwrap();
+                let val = T::from(val).unwrap();
                 assert_eq!(func(n, k), val);
             }
         }
@@ -201,17 +206,18 @@ mod tests {
     fn comb() {
         // Generated from scipy
         let ref_values = [
-            [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-            [1, 2, 1, 0, 0, 0, 0, 0, 0, 0],
-            [1, 3, 3, 1, 0, 0, 0, 0, 0, 0],
-            [1, 4, 6, 4, 1, 0, 0, 0, 0, 0],
-            [1, 5, 10, 10, 5, 1, 0, 0, 0, 0],
-            [1, 6, 15, 20, 15, 6, 1, 0, 0, 0],
-            [1, 7, 21, 35, 35, 21, 7, 1, 0, 0],
-            [1, 8, 28, 56, 70, 56, 28, 8, 1, 0],
-            [1, 9, 36, 84, 126, 126, 84, 36, 9, 1],
+           [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+           [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+           [1, 2, 1, 0, 0, 0, 0, 0, 0, 0],
+           [1, 3, 3, 1, 0, 0, 0, 0, 0, 0],
+           [1, 4, 6, 4, 1, 0, 0, 0, 0, 0],
+           [1, 5, 10, 10, 5, 1, 0, 0, 0, 0],
+           [1, 6, 15, 20, 15, 6, 1, 0, 0, 0],
+           [1, 7, 21, 35, 35, 21, 7, 1, 0, 0],
+           [1, 8, 28, 56, 70, 56, 28, 8, 1, 0],
+           [1, 9, 36, 84, 126, 126, 84, 36, 9, 1],
         ];
+        check_values(&ref_values, u32::comb);
         check_values(&ref_values, i32::comb);
     }
 
@@ -227,6 +233,7 @@ mod tests {
 
     #[test]
     fn comb_rep() {
+        // Generated from scipy
         let ref_values = [
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
@@ -239,7 +246,7 @@ mod tests {
             [1, 8, 36, 120, 330, 792, 1716, 3432, 6435, 11440],
             [1, 9, 45, 165, 495, 1287, 3003, 6435, 12870, 24310],
         ];
-
+        check_values(&ref_values, u32::comb_rep);
         check_values(&ref_values, i32::comb_rep);
     }
 
@@ -268,6 +275,7 @@ mod tests {
             [1, 8, 56, 336, 1680, 6720, 20160, 40320, 40320, 0],
             [1, 9, 72, 504, 3024, 15120, 60480, 181440, 362880, 362880],
         ];
+        check_values(&ref_values, u32::perm);
         check_values(&ref_values, i32::perm);
     }
 
@@ -296,6 +304,7 @@ mod tests {
             [0, 1, 127, 966, 1701, 1050, 266, 28, 1, 0],
             [0, 1, 255, 3025, 7770, 6951, 2646, 462, 36, 1],
         ];
+        check_values(&ref_values, u32::stirling2);
         check_values(&ref_values, i32::stirling2);
     }
 

--- a/sci-rs/src/special/combinatorics.rs
+++ b/sci-rs/src/special/combinatorics.rs
@@ -187,9 +187,9 @@ mod tests {
     use super::*;
     use core::fmt;
 
-    fn check_values<K, T>(ref_values: &[[K;10]], func: fn(T, T) -> T)
+    fn check_values<K, T>(ref_values: &[[K; 10]], func: fn(T, T) -> T)
     where
-        K: PrimInt + FromPrimitive, 
+        K: PrimInt + FromPrimitive,
         T: PrimInt + FromPrimitive + fmt::Debug,
     {
         for (n, &elements) in ref_values.iter().enumerate() {
@@ -206,16 +206,16 @@ mod tests {
     fn comb() {
         // Generated from scipy
         let ref_values = [
-           [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-           [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-           [1, 2, 1, 0, 0, 0, 0, 0, 0, 0],
-           [1, 3, 3, 1, 0, 0, 0, 0, 0, 0],
-           [1, 4, 6, 4, 1, 0, 0, 0, 0, 0],
-           [1, 5, 10, 10, 5, 1, 0, 0, 0, 0],
-           [1, 6, 15, 20, 15, 6, 1, 0, 0, 0],
-           [1, 7, 21, 35, 35, 21, 7, 1, 0, 0],
-           [1, 8, 28, 56, 70, 56, 28, 8, 1, 0],
-           [1, 9, 36, 84, 126, 126, 84, 36, 9, 1],
+            [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+            [1, 2, 1, 0, 0, 0, 0, 0, 0, 0],
+            [1, 3, 3, 1, 0, 0, 0, 0, 0, 0],
+            [1, 4, 6, 4, 1, 0, 0, 0, 0, 0],
+            [1, 5, 10, 10, 5, 1, 0, 0, 0, 0],
+            [1, 6, 15, 20, 15, 6, 1, 0, 0, 0],
+            [1, 7, 21, 35, 35, 21, 7, 1, 0, 0],
+            [1, 8, 28, 56, 70, 56, 28, 8, 1, 0],
+            [1, 9, 36, 84, 126, 126, 84, 36, 9, 1],
         ];
         check_values(&ref_values, u32::comb);
         check_values(&ref_values, i32::comb);

--- a/sci-rs/src/special/combinatorics.rs
+++ b/sci-rs/src/special/combinatorics.rs
@@ -187,17 +187,17 @@ mod tests {
     use super::*;
     use core::fmt;
 
-    fn check_values<K, T>(ref_values: &[[K; 10]], func: fn(T, T) -> T)
+    fn check_values<K, T>(ref_values: &[[K; 10]], func: fn(T, T) -> T, func_name: &str)
     where
         K: PrimInt + FromPrimitive,
-        T: PrimInt + FromPrimitive + fmt::Debug,
+        T: PrimInt + FromPrimitive + fmt::Display + fmt::Debug,
     {
         for (n, &elements) in ref_values.iter().enumerate() {
             for (k, &val) in elements.iter().enumerate() {
                 let n = T::from_usize(n).unwrap();
                 let k = T::from_usize(k).unwrap();
                 let val = T::from(val).unwrap();
-                assert_eq!(func(n, k), val);
+                assert_eq!(func(n, k), val, "{}({}, {}) != {}", func_name, n, k, val);
             }
         }
     }
@@ -217,8 +217,8 @@ mod tests {
             [1, 8, 28, 56, 70, 56, 28, 8, 1, 0],
             [1, 9, 36, 84, 126, 126, 84, 36, 9, 1],
         ];
-        check_values(&ref_values, u32::comb);
-        check_values(&ref_values, i32::comb);
+        check_values(&ref_values, u32::comb, "u32::comb");
+        check_values(&ref_values, i32::comb, "i32::comb");
     }
 
     #[test]
@@ -246,8 +246,8 @@ mod tests {
             [1, 8, 36, 120, 330, 792, 1716, 3432, 6435, 11440],
             [1, 9, 45, 165, 495, 1287, 3003, 6435, 12870, 24310],
         ];
-        check_values(&ref_values, u32::comb_rep);
-        check_values(&ref_values, i32::comb_rep);
+        check_values(&ref_values, u32::comb_rep, "u32::comb_rep");
+        check_values(&ref_values, i32::comb_rep, "i32::comb_rep");
     }
 
     #[test]
@@ -275,8 +275,8 @@ mod tests {
             [1, 8, 56, 336, 1680, 6720, 20160, 40320, 40320, 0],
             [1, 9, 72, 504, 3024, 15120, 60480, 181440, 362880, 362880],
         ];
-        check_values(&ref_values, u32::perm);
-        check_values(&ref_values, i32::perm);
+        check_values(&ref_values, u32::perm, "u32::perm");
+        check_values(&ref_values, i32::perm, "i32::perm");
     }
 
     #[test]
@@ -304,8 +304,8 @@ mod tests {
             [0, 1, 127, 966, 1701, 1050, 266, 28, 1, 0],
             [0, 1, 255, 3025, 7770, 6951, 2646, 462, 36, 1],
         ];
-        check_values(&ref_values, u32::stirling2);
-        check_values(&ref_values, i32::stirling2);
+        check_values(&ref_values, u32::stirling2, "u32::stirling2");
+        check_values(&ref_values, i32::stirling2, "i32::stirling2");
     }
 
     #[test]

--- a/sci-rs/src/special/combinatorics.rs
+++ b/sci-rs/src/special/combinatorics.rs
@@ -43,6 +43,24 @@ pub trait Combinatoric {
     ///
     /// [wiki]: https://en.wikipedia.org/wiki/Combination#Number_of_combinations_with_repetition
     fn comb_rep(self, k: Self) -> Self;
+
+    /// Number of permutations of `n` things taken `k` at a time.
+    ///
+    /// Also known as the `k`-permutation of `n`.
+    /// $$
+    /// \text{Perm}(n, k) = \frac{n!}{(n-k)!}
+    /// $$
+    /// # Examples
+    /// ```
+    /// use sci_rs::special::Combinatoric;
+    /// assert_eq!(5.perm(5), 120); // should be 5!
+    /// assert_eq!(5.perm(0), 1);
+    /// assert_eq!(6.perm(3), 6*5*4);
+    /// ```
+    ///
+    /// # Notes
+    /// When `n<0` or `k<0`, the `0` is returned. 
+    fn perm(self, k: Self) -> Self;
 }
 
 macro_rules! combinatoric_primint_impl {
@@ -56,6 +74,11 @@ macro_rules! combinatoric_primint_impl {
             #[inline(always)]
             fn comb_rep(self, k: Self) -> Self {
                 primint_comb_rep(self, k)
+            }
+
+            #[inline(always)]
+            fn perm(self, k:Self) -> Self {
+                primint_perm(self, k)         
             }
 
         }
@@ -83,6 +106,16 @@ where
     Int: PrimInt + FromPrimitive,
 {
     primint_comb(n + k - Int::one(), k)
+}
+
+fn primint_perm<Int>(n: Int, k: Int) -> Int where Int: PrimInt + FromPrimitive {
+    if k > n ||n < Int::zero() || k < Int::zero() {
+        return Int::zero();
+    }
+
+    let start = (n - k + Int::one()).to_usize().unwrap();
+    let end = (n + Int::one()).to_usize().unwrap();
+    (start..end).fold(Int::one(), |result, val| result * Int::from_usize(val).unwrap())
 }
 
 #[cfg(test)]
@@ -169,6 +202,44 @@ mod tests {
             for j in 0..1 {
                 assert_eq!(i.comb_rep(j), i);
             }
+        }
+    }
+    
+    #[test]
+    fn perm() {
+        let ref_values_4 = [1, 4, 12, 24, 24, 0];
+        let ref_values_7 = [1, 7, 42, 210, 840, 2520, 5040, 5040, 0];
+        let ref_values_13 = [
+            1, 13, 156, 1716, 17160, 154440, 1235520, 8648640, 51891840, 259459200, 1037836800,
+        ];
+        check_values(4, &ref_values_4, i32::perm);
+        check_values(7, &ref_values_7, i32::perm);
+        check_values(13, &ref_values_13, i32::perm);
+    }
+
+    #[test]
+    fn perm_edge() {
+        assert_eq!(0.perm(0), 1);
+        assert_eq!(1.perm(0), 1);
+        assert_eq!(0.perm(1), 0);
+    }
+    
+    #[test]
+    fn perm_negative() {
+        for i in 0..4 {
+            assert_eq!((-4).perm(i), 0);
+            assert_eq!((-3).perm(i), 0);
+            assert_eq!((-3241).perm(i), 0);
+        }
+
+        for i in -4..0 {
+            assert_eq!(4.perm(i), 0);
+            assert_eq!(2.perm(i), 0);
+            assert_eq!(2341.perm(i), 0);
+            assert_eq!((-2).perm(i), 0);
+            assert_eq!((-4).perm(i), 0);
+            assert_eq!((-5).perm(i), 0);
+            assert_eq!((-3241).perm(i), 0);
         }
     }
 }

--- a/sci-rs/src/special/combinatorics.rs
+++ b/sci-rs/src/special/combinatorics.rs
@@ -2,7 +2,7 @@ use nalgebra::min;
 use num_traits::{FromPrimitive, PrimInt};
 
 /// Various combinatorics functions for integer types.
-pub trait Comb {
+pub trait Combinatoric {
     /// The number of combinations of `n` taken `k` at a time.
     ///
     /// This is also known as $n$ choose $k$ and is generally given by the formula
@@ -14,7 +14,7 @@ pub trait Comb {
     ///
     /// # Examples
     /// ```
-    /// use sci_rs::special::Comb;
+    /// use sci_rs::special::Combinatoric;
     /// assert_eq!(5_i32.comb(2), 10);
     /// ```
     ///
@@ -30,7 +30,7 @@ pub trait Comb {
     ///
     /// # Examples
     /// ```
-    /// use sci_rs::special::Comb;
+    /// use sci_rs::special::Combinatoric;
     /// assert_eq!(5_i32.comb_rep(2), 15);
     /// assert_eq!(10_i32.comb_rep(3), 220);
     /// ```
@@ -45,9 +45,9 @@ pub trait Comb {
     fn comb_rep(self, k: Self) -> Self;
 }
 
-macro_rules! comb_primint_impl {
+macro_rules! combinatoric_primint_impl {
     ($($T: ty)*) => ($(
-        impl Comb for $T {
+        impl Combinatoric for $T {
             #[inline(always)]
             fn comb(self, k: Self) -> Self {
                 primint_comb(self, k)
@@ -62,7 +62,7 @@ macro_rules! comb_primint_impl {
     )*)
 }
 
-comb_primint_impl! {u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize}
+combinatoric_primint_impl! {u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize}
 
 fn primint_comb<Int>(n: Int, k: Int) -> Int
 where


### PR DESCRIPTION
Given discussion in #53, I have modified the combinatorics functions to be a trait `Comb`. The trait is implemented for primitive integer types: `u8`, `u16`, `u32`, `u64`, `u128`, `usize`, `i8`, `i16`, `i32`, `i64`, `i128`, `isize` using a macro to stamp out the trivial implementations.

I think this will help me better understand how to implement the rest of the special math functions going forward, if I have a good idea of how to implement these interfaces.

Would love thoughts/revisions to this general interface design (especially for functions which operate on primitive integers/floats.