### PR TITLE
Initial landing of Core

### DIFF
--- a/sci-rs-core/Cargo.toml
+++ b/sci-rs-core/Cargo.toml
@@ -26,5 +26,5 @@ std = ['alloc']
 
 [dependencies]
 ndarray = { version = "0.16.1", default-features = false }
-ndarray-conv = { version = "0.4.1" }
+ndarray-conv = { version = "0.5.0" }
 num-traits = { version = "0.2.15", default-features = false }

--- a/sci-rs-core/Cargo.toml
+++ b/sci-rs-core/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "sci-rs-core"
+version = "0.0.0"
+edition = "2021"
+authors = ["Jacob Trueb <jtrueb@northwestern.edu>"]
+description = "Core library for sci-rs internals."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/qsib-cbie/sci-rs.git"
+homepage = "https://github.com/qsib-cbie/sci-rs.git"
+readme = "../README.md"
+keywords = ["scipy", "dsp", "signal", "filter", "design"]
+categories = ["science", "mathematics", "no-std", "embedded"]
+
+
+[package.metadata.docs.rs]
+all-features = true
+
+[features]
+default = ['alloc']
+
+# Allow allocating vecs, matrices, etc.
+alloc = []
+
+# Enable FFT and standard library features
+std = ['alloc']
+
+[dependencies]
+ndarray = { version = "0.16.1", default-features = false }
+ndarray-conv = { version = "0.4.1" }
+num-traits = { version = "0.2.15", default-features = false }

--- a/sci-rs-core/src/lib.rs
+++ b/sci-rs-core/src/lib.rs
@@ -18,12 +18,18 @@ pub enum Error {
         /// Explaining why arg is invalid.
         reason: alloc::string::String,
     },
+    /// Argument parsed into function were invalid.
+    #[cfg(not(feature = "alloc"))]
+    InvalidArg,
     /// Two or more optional arguments passed into functions conflict.
     #[cfg(feature = "alloc")]
-    ConfictArg {
+    ConflictArg {
         /// Explaining what arg is invalid.
         reason: alloc::string::String,
     },
+    /// Two or more optional arguments passed into functions conflict.
+    #[cfg(not(feature = "alloc"))]
+    ConflictArg,
 }
 
 impl fmt::Display for Error {

--- a/sci-rs-core/src/lib.rs
+++ b/sci-rs-core/src/lib.rs
@@ -4,6 +4,8 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+#[cfg(feature = "alloc")]
+use alloc::format;
 
 use core::{error, fmt};
 
@@ -36,7 +38,24 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+        write!(
+            f,
+            "{}",
+            match self {
+                #[cfg(feature = "alloc")]
+                Error::InvalidArg { arg, reason } =>
+                    format!("Invalid Argument on arg = {} with reason = {}", arg, reason),
+                #[cfg(not(feature = "alloc"))]
+                Error::InvalidArg =>
+                    "There were invalid arguments. Reasons not shown without `alloc` feature.",
+                #[cfg(feature = "alloc")]
+                Error::ConflictArg { reason } =>
+                    format!("Conflicting Arguments with reason = {}", reason),
+                #[cfg(not(feature = "alloc"))]
+                Error::ConflictArg =>
+                    "There were conflicting arguments. Reasons not shown without `alloc` feature.",
+            }
+        )
     }
 }
 

--- a/sci-rs-core/src/lib.rs
+++ b/sci-rs-core/src/lib.rs
@@ -7,6 +7,8 @@ extern crate alloc;
 
 use core::{error, fmt};
 
+pub type Result<T> = core::result::Result<T, Error>;
+
 /// Errors raised whilst running sci-rs.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {

--- a/sci-rs-core/src/lib.rs
+++ b/sci-rs-core/src/lib.rs
@@ -1,0 +1,35 @@
+//! Core library for sci-rs.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+use core::{error, fmt};
+
+/// Errors raised whilst running sci-rs.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    /// Argument parsed into function were invalid.
+    #[cfg(feature = "alloc")]
+    InvalidArg {
+        /// The invalid arg
+        arg: alloc::string::String,
+        /// Explaining why arg is invalid.
+        reason: alloc::string::String,
+    },
+    /// Two or more optional arguments passed into functions conflict.
+    #[cfg(feature = "alloc")]
+    ConfictArg {
+        /// Explaining what arg is invalid.
+        reason: alloc::string::String,
+    },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+impl error::Error for Error {}


### PR DESCRIPTION
As discussed from #53, we begin the migration by first introducing the -core crate.
By using the version number as being 0.0.0, we show strictly that it's meant to be a internal crate.

I believe we can start defining the common traits necessary on non-NAN floats, integers etc here too. I am not sure at present if this conflicts with the internal crate requirement.

Currently just providing a minimal set of Error enums as cherry-picked, with non-allocating variants.
The fmt::Display for the error and a README.md is to be decided in the future.

Edit:
The results as shown in #78 and #86 might show that the current Errors might be strictly insufficient are require more thought. It might be worth seriously considering `anyhow`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce new `sci-rs-core` crate with no_std-ready core error types, feature gates, and base deps.
> 
> - **Core crate**: Add `sci-rs-core` with `no_std` support and feature flags.
>   - Features: `alloc` (default), `std` (enables `alloc`).
>   - Metadata: docs.rs `all-features = true`.
>   - Deps: `ndarray`, `ndarray-conv`, `num-traits` (minimal default features).
> - **Error handling**:
>   - New `Error` enum with `InvalidArg` and `ConflictArg` variants.
>     - Allocating variants (with `String`) under `alloc`.
>     - Non-alloc fallbacks without payloads when `alloc` is disabled.
>   - `fmt::Display` and `core::error::Error` impls with conditional messaging.
>   - `Result<T>` type alias to `core::result::Result<T, Error>`.
> - **Files**:
>   - `sci-rs-core/Cargo.toml`
>   - `sci-rs-core/src/lib.rs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f21a6bcdfe7f45304083821e52dffe9a1789e5c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->