### PR TITLE
Add PartialEq support on FilterType

### DIFF
--- a/sci-rs/src/signal/filter/design/filter_type.rs
+++ b/sci-rs/src/signal/filter/design/filter_type.rs
@@ -1,4 +1,5 @@
 /// Type of IIR filter
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FilterType {
     /// Butterworth
     /// <https://en.wikipedia.org/wiki/Butterworth_filter>
@@ -18,6 +19,7 @@ pub enum FilterType {
 }
 
 /// Bessel-Thomson filter normalization
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BesselThomsonNorm {
     /// Phase
     Phase,


### PR DESCRIPTION
Hello :wave: 

While using sci-rs filter I came across an issue where `PartialEq` trait wasn't implemented for `FilterType` while it's in implemented for `FilterBandType`.
This PR implements this missing trait. 

Apart from that, do you have an idea of when the next release is planned?

Thank you.