### PR TITLE
clippy: Fix other clippy warnings from 1.90

### DIFF
--- a/sci-rs/src/signal/filter/design/iirfilter.rs
+++ b/sci-rs/src/signal/filter/design/iirfilter.rs
@@ -275,7 +275,7 @@ where
         .map(|z| -(*z))
         .fold(Complex::new(F::one(), F::zero()), |acc, z| acc * z)
         .real();
-    if n % 2 == 0 {
+    if n.is_multiple_of(2) {
         k /= Float::sqrt(F::one() + eps * eps);
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace `n % 2 == 0` with `n.is_multiple_of(2)` in `cheb1ap_dyn` to satisfy clippy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 092565cd9719e7fc0d5e4f95fd2ab1857034bc41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->