### PR TITLE
Update dev-dependency: `rand` to 0.9.2

### DIFF
--- a/sci-rs/Cargo.toml
+++ b/sci-rs/Cargo.toml
@@ -41,7 +41,7 @@ gaussfilt = { version = "0.1.3", default-features = false }
 approx = "0.5.1"
 dasp_signal = { version = "0.11.0" }
 criterion = { version = "0.4", features = ["html_reports"] }
-rand = "0.8.4"
+rand = "0.9.2"
 
 [[bench]]
 name = "sosfilt"

--- a/sci-rs/src/signal/convolve.rs
+++ b/sci-rs/src/signal/convolve.rs
@@ -173,12 +173,12 @@ mod tests {
     #[test]
     #[cfg(feature = "plot")]
     fn test_scipy_example() {
-        use rand::distributions::{Distribution, Standard};
-        use rand::thread_rng;
+        use rand::distr::{Distribution, StandardUniform};
+        use rand::rng;
 
         // Generate 1000 random samples from standard normal distribution
-        let mut rng = thread_rng();
-        let sig: Vec<f64> = Standard.sample_iter(&mut rng).take(1000).collect();
+        let mut rng = rng();
+        let sig: Vec<f64> = StandardUniform.sample_iter(&mut rng).take(1000).collect();
 
         // Compute autocorrelation using correlate directly
         let autocorr = correlate(&sig, &sig, ConvolveMode::Full);

--- a/sci-rs/src/signal/resample.rs
+++ b/sci-rs/src/signal/resample.rs
@@ -87,22 +87,18 @@ mod tests {
         // Resample each to length 100
         // Check that each resampled vector is length 100
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         for i in (0..100) {
-            let len = rng.gen_range((10..50));
-            let x = (0..len)
-                .map(|_| rng.gen_range((-100.0..100.)))
-                .collect::<Vec<_>>();
+            let len = rng.random_range(10..50);
+            let x: Vec<_> = (0..len).map(|_| rng.random_range(-100.0..100.)).collect();
             let y = resample(&x, 100);
             assert_eq!(y.len(), 100);
         }
 
         for i in (0..50) {
-            let len = rng.gen_range((200..10000));
-            let target_len = rng.gen_range((50..50000));
-            let x = (0..len)
-                .map(|_| rng.gen_range((-100.0..100.)))
-                .collect::<Vec<_>>();
+            let len = rng.random_range(200..10000);
+            let target_len = rng.random_range(50..50000);
+            let x: Vec<_> = (0..len).map(|_| rng.random_range(-100.0..100.)).collect();
             let y = resample(&x, target_len);
             assert_eq!(y.len(), target_len);
         }


### PR DESCRIPTION
Deprecated methods are changed for newer methods.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `rand` dev-dependency to 0.9.2 and updates tests to the new RNG/distr API (`rng()`, `random_range`, `distr` paths).
> 
> - **Dependencies**:
>   - Bump `rand` in `sci-rs/Cargo.toml` dev-deps from `0.8.4` to `0.9.2`.
> - **Tests**:
>   - Migrate RNG usage to `rand` 0.9 in `sci-rs/src/signal/convolve.rs` (plot-only test) and `sci-rs/src/signal/resample.rs`:
>     - Replace `thread_rng()` with `rng()`.
>     - Replace `gen_range` with `random_range`.
>     - Switch from `distributions::{Distribution, Standard}` to `distr::{Distribution, StandardUniform}` and update `sample_iter` calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74893088f9d16b11ae116d3d021689044602cdfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->