### PR TITLE
Minor fixes on `boxcar` and `lfilter`

### DIFF
--- a/sci-rs/src/signal/filter/lfilter.rs
+++ b/sci-rs/src/signal/filter/lfilter.rs
@@ -92,8 +92,8 @@ where
         zi: Option<ArrayView<T, Dim<[Ix; N]>>>,
     ) -> Result<LFilterResult<T, N>>
     where
-        T: NumAssign + FromPrimitive + Copy + 'a,
-        S: Data<Elem = T> + 'a;
+        T: NumAssign + FromPrimitive + Copy,
+        S: Data<Elem = T>;
 }
 
 macro_rules! lfilter_for_dim {
@@ -110,8 +110,7 @@ macro_rules! lfilter_for_dim {
                 zi: Option<ArrayView<T, Dim<[Ix; $N]>>>,
             ) -> Result<(Array<T, Dim<[Ix; $N]>>, Option<Array<T, Dim<[Ix; $N]>>>)>
             where
-                T: NumAssign + FromPrimitive + Copy + 'a,
-                S: 'a,
+                T: NumAssign + FromPrimitive + Copy,
             {
                 if a.len() > 1 {
                     return linear_filter(b, a, x, axis, zi);
@@ -651,8 +650,7 @@ fn linear_filter<'a, T, S, D>(
 ) -> Result<LFilterDynResult<T, D>>
 where
     D: Dimension,
-    T: 'a,
-    S: Data<Elem = T> + 'a,
+    S: Data<Elem = T>,
 {
     todo!()
 }

--- a/sci-rs/src/signal/windows/boxcar.rs
+++ b/sci-rs/src/signal/windows/boxcar.rs
@@ -57,7 +57,7 @@ where
     #[cfg(feature = "alloc")]
     fn get_window(&self) -> Vec<W> {
         if len_guard(self.m) {
-            return Vec::<W>::new();
+            return vec![W::one(); self.m];
         }
         let (m, needs_trunc) = extend(self.m, self.sym);
 
@@ -74,9 +74,17 @@ mod test {
     use super::*;
 
     #[test]
-    fn case_a() {
+    fn boxcar_case_a() {
         let nx = 5;
         let boxcar = Boxcar::new(nx, false);
+        let window: Vec<f64> = boxcar.get_window();
+        assert_eq!(vec![1.; nx], window);
+    }
+
+    #[test]
+    fn boxcar_case_b() {
+        let nx = 1;
+        let boxcar = Boxcar::new(nx, true);
         let window: Vec<f64> = boxcar.get_window();
         assert_eq!(vec![1.; nx], window);
     }


### PR DESCRIPTION
PR that touches up on minor matters:

1. Fixup wrong `boxcar`
2. Relaxes constraints on `lfilter`